### PR TITLE
Update DatabaseRepository.php

### DIFF
--- a/src/Repositories/DatabaseRepository.php
+++ b/src/Repositories/DatabaseRepository.php
@@ -37,7 +37,7 @@ class DatabaseRepository extends Repository
      */
     public function __construct()
     {
-        $this->connection = config('database.connection');
+        $this->connection = config('settings.repositories.database.connection');
 
         $this->table = config('settings.repositories.database.table');
 


### PR DESCRIPTION
The setting config('database.connection') does not exist. It only works because null is returned and then it uses the default connection. This should be changed to config('settings.repositories.database.connection').